### PR TITLE
Update examples to be v4 compatible

### DIFF
--- a/src/examples/adux.ts
+++ b/src/examples/adux.ts
@@ -3,14 +3,16 @@ import {ConfigExample} from "./index";
 const ADux: ConfigExample = {
     label: "A. dux",
     author: "tapioki",
-    value: `points:
+    value: `
+points:
   zones:
     matrix:
       columns:
         pinky:
-          spread: 18
-          rotate: 15
-          origin: [0, -17]
+          key:
+            spread: 18
+            splay: 15
+            origin: [0, -17]
           rows:
             bottom:
               bind: [5, 0, 0, 0]
@@ -22,10 +24,11 @@ const ADux: ConfigExample = {
               bind: [0, 8, 5, 0]
               column_net: P5 
         ring:
-          spread: 18
-          stagger: 17
-          rotate: -10
-          origin: [0, -17]
+          key:
+            spread: 18
+            stagger: 17
+            splay: -10
+            origin: [0, -17]
           rows:
             bottom:
               bind: [0, 0, 2, 10]
@@ -34,30 +37,31 @@ const ADux: ConfigExample = {
               bind: [5, 0, 5, 0]
               column_net: P3
             top:
-              bind: [0, 5, 0, 0]
+              bind: [0, 6, 0, 0]
               column_net: P0
         middle:
-          spread: 18
-          stagger: 17/3
-          rotate: -5
-          origin: [0, -17]
+          key:
+            shift: [0.2, 0]
+            spread: 18
+            stagger: 17/3
+            splay: -5
+            origin: [0, -17]
           rows:
             bottom:
               bind: [0, 10, 0, 5]
               column_net: P1
             home:
               bind: 5
-              column_net: P19           
+              column_net: P19
             top:
               bind: [0, 0, 0, 0]
               column_net: P18
-          key:
-            shift: [0.2, 0]
         index:
-          spread: 18
-          stagger: -17/3
-          rotate: -5
-          origin: [0, -17]
+          key:
+            spread: 18
+            stagger: -17/3
+            splay: -5
+            origin: [0, -17]
           rows:
             bottom:
               bind: [0, 5, 0, 0]
@@ -69,9 +73,10 @@ const ADux: ConfigExample = {
               bind: [0, 0, 0, 6]
               column_net: P16
         inner:
-          spread: 18
-          stagger: -17/6
-          origin: [0, -17]
+          key:
+            spread: 18
+            stagger: -17/6
+            origin: [0, -17]
           rows: 
             bottom:
               bind: [5, 19, 20, 2]
@@ -82,27 +87,6 @@ const ADux: ConfigExample = {
             top:
               bind: [0, 0, 5, 5]
               column_net: P21
-      key:
-        footprints:
-          choc_hotswap:
-            type: choc
-            nets:
-              from: =column_net
-              to: GND
-            params:
-                keycaps: true
-                reverse: true
-                hotswap: true
-          choc:
-            type: choc
-            anchor:
-              rotate: 180
-            nets:
-              from: =column_net
-              to: GND
-            params:
-                keycaps: true
-                reverse: true
       rows:
         bottom:
           padding: 17
@@ -115,15 +99,17 @@ const ADux: ConfigExample = {
         shift: [0,-24]
       columns:
         first:
-          rotate: -15
+          key:
+            splay: -15
           rows:
             only:
               column_net: P8
               bind: [10, 1, 0, 70]
         second:
-          spread: 18
-          rotate: -10
-          origin: [-9, -9.5]
+          key:
+            spread: 18
+            splay: -10
+            origin: [-9, -9.5]
           rows:
             only:
               column_net: P9
@@ -133,73 +119,73 @@ const ADux: ConfigExample = {
           padding: 17
       key:
         footprints:
-          choc_hotswap:
-            type: choc
-            nets:
-              from: =column_net
-              to: GND
-            params:
-                keycaps: true
-                reverse: true
-                hotswap: true
-          choc:
-            type: choc
-            anchor:
-              rotate: 180
-            nets:
-              from: =column_net
-              to: GND
-            params:
-                keycaps: true
-                reverse: true
 outlines:
-  exports:
-    raw:
-      - type: keys
-        side: left
-        size: [18,17]
-        corner: 1
-    first:
-      - type: outline
-        name: raw
-        fillet: 3
-    second:
-      - type: outline
-        name: first
-        fillet: 2
-    third:
-      - type: outline
-        name: second
-        fillet: 1   
-    panel:
-      - type: outline
-        name: third
-        fillet: 0.5
+  raw:
+    - what: rectangle
+      where: true
+      bound: true
+      asym: left
+      size: [18,17]
+      corner: 1
+  first:
+    - what: outline
+      name: raw
+      fillet: 3
+  second:
+    - what: outline
+      name: first
+      fillet: 2
+  third:
+    - what: outline
+      name: second
+      fillet: 1
+  panel:
+    - what: outline
+      name: third
+      fillet: 0.5
 pcbs:
   architeuthis_dux:
     outlines:
       main:
         outline: panel
     footprints:
+      choc_hotswap:
+        what: choc
+        where: true
+        params:
+          from: =column_net
+          to: GND
+          keycaps: true
+          reverse: true
+          hotswap: true
+      choc:
+        what: choc
+        where: true
+        adjust:
+          rotate: 180
+        params:
+          from: =column_net
+          to: GND
+          keycaps: true
+          reverse: true
       promicro:
-        type: promicro
-        anchor:
+        what: promicro
+        where:
           ref: matrix_inner_home
           shift: [19, -8.5]
           rotate: -90
         params:
           orientation: down
       trrs:
-        type: trrs
-        nets:
+        what: trrs
+        where:
+          ref: matrix_inner_home
+          shift: [34.75, 6.5]
+        params:
           A: GND
           B: GND
           C: P2
           D: VCC
-        anchor:
-          ref: matrix_inner_home
-          shift: [34.75, 6.5]
-        params:
           reverse: true
           symmetric: true
 `

--- a/src/examples/alpha.ts
+++ b/src/examples/alpha.ts
@@ -3,7 +3,8 @@ import {ConfigExample} from "./index";
 const Alpha: ConfigExample = {
     label: "Alpha (staggered bottom row)",
     author: "jcmkk3",
-    value: `points:
+    value: `
+points:
   mirror:
     ref: ortho_inner_home
     distance: 1U
@@ -29,12 +30,13 @@ const Alpha: ConfigExample = {
         index:
           key.asym: left
         space:
-          spread: 0.5U
           key:
+            spread: 0.5U
             asym: right
-            width: 2
+            width: 2*(u-1)
       rows:
-        bottom.padding: 1U`
+        bottom.padding: 1U
+`
 };
 
 export default Alpha;

--- a/src/examples/atreus.ts
+++ b/src/examples/atreus.ts
@@ -3,23 +3,25 @@ import {ConfigExample} from "./index";
 const Atreus: ConfigExample = {
     label: "Atreus (simplified)",
     author: "MrZealot",
-    value: `points:
+    value: `
+points:
   zones:
     matrix:
       columns:
         pinky:
         ring:
-          stagger: 3
+          key.stagger: 3
         middle:
-          stagger: 5
+          key.stagger: 5
         index:
-          stagger: -5
+          key.stagger: -5
         inner:
-          stagger: -6
+          key.stagger: -6
         thumb:
-          stagger: 10
-          row_overrides:
-            home:
+          key.skip: true
+          key.stagger: 10
+          rows:
+            home.skip: false
       rows:
         bottom:
         home:
@@ -28,7 +30,8 @@ const Atreus: ConfigExample = {
   rotate: -10
   mirror:
     ref: matrix_thumb_home
-    distance: 22`
+    distance: 22
+`
 };
 
 export default Atreus;

--- a/src/examples/plank.ts
+++ b/src/examples/plank.ts
@@ -3,7 +3,8 @@ import {ConfigExample} from "./index";
 const Reviung41: ConfigExample = {
     label: "Plank (ortholinear, 2u space)",
     author: "cache.works",
-    value: `units:
+    value: `
+units:
   visual_x: 17.5
   visual_y: 16.5
 points:
@@ -15,33 +16,33 @@ points:
             column_net: P1
             column_mark: 1
         two:
-          spread: 1cx
           key:
+            spread: 1cx
             column_net: P0
             column_mark: 2
         three:
-          spread: 1cx
           key:
+            spread: 1cx
             column_net: P14
             column_mark: 3
         four:
-          spread: 1cx
           key:
+            spread: 1cx
             column_net: P20
             column_mark: 4
         five:
-          spread:  1cx
           key:
+            spread:  1cx
             column_net: P2
             column_mark: 5
         six:
-          spread:  1cx
           key:
+            spread:  1cx
             column_net: P3
             column_mark: 6
         seven:
-          spread:  1cx
           key:
+            spread:  1cx
             column_net: P4
             column_mark: 7
           rows:
@@ -49,29 +50,32 @@ points:
               skip: false
               shift: [-0.5cx, 1cy]
               rotate: 180
+            modrow:
+              shift: [-0.5cx, -1cy]
+              rotate: 180
         eight:
-          spread:  1cx
           key:
+            spread:  1cx
             column_net: P5
             column_mark: 8
         nine:
-          spread:  1cx
           key:
+            spread:  1cx
             column_net: P6
             column_mark: 9
         ten:
-          spread:  1cx
           key:
+            spread:  1cx
             column_net: P7
             column_mark: 10
         eleven:
-          spread:  1cx
           key:
+            spread:  1cx
             column_net: P8
             column_mark: 11
         twelve:
-          spread:  1cx
           key:
+            spread:  1cx
             column_net: P9
             column_mark: 12
       rows:
@@ -93,84 +97,81 @@ points:
           row_net: P21
   key:
     bind: 2
-    footprints:
-      choc:
-        type: choc
-        anchor:
-        nets:
-          from: =colrow
-          to: =column_net
-        params:
-          keycaps: true
-      diode:
-        type: diode
-        anchor:
-          rotate: 0
-          shift: [ 0, -4.5 ]
-        nets:
-          from: =colrow
-          to: =row_net
-        params:
-          via_in_pad: true
-          through_hole: false
 outlines:
-  exports:
-    raw:
-      - type: keys
-        side: left
-        size: [1cx,1cy]
-        corner: 1
-    panel:
-      - type: outline
-        name: raw
-        fillet: 0.5
-    switch_cutouts:
-      - type: keys
-        side: left
-        size: 14
-        bound: false
-    switch_plate:
-      main:
-        type: outline
-        name: panel
-        fillet: 0.5
-      keyholes:
-        type: outline
-        name: switch_cutouts
-        operation: subtract
+  raw:
+    - what: rectangle
+      where: true
+      asym: left
+      size: [1cx,1cy]
+      corner: 1
+  panel:
+    - what: outline
+      name: raw
+      fillet: 0.5
+  switch_cutouts:
+    - what: rectangle
+      where: true
+      asym: left
+      size: 14
+      bound: false
+  switch_plate:
+    main:
+      what: outline
+      name: panel
+      fillet: 0.5
+    keyholes:
+      what: outline
+      name: switch_cutouts
+      operation: subtract
 pcbs:
   plank:
     outlines:
       main:
         outline: panel
     footprints:
+      choc:
+        what: choc
+        where: true
+        params:
+          from: "{{colrow}}"
+          to: "{{column_net}}"
+          keycaps: true
+      diode:
+        what: diode
+        where: true
+        adjust:
+          rotate: 0
+          shift: [ 0, -4.5 ]
+        params:
+          from: "{{colrow}}"
+          to: "{{row_net}}"
+          # via_in_pad: true
+          # through_hole: false
       promicro:
-        type: promicro
-        anchor:
+        what: promicro
+        where:
           ref: matrix_seven_top
           shift: [-0.5cx, 1]
         params:
           orientation: down
       powerswitch:
-        type: slider
-        anchor:
+        what: slider
+        where:
           ref: matrix_four_top
           shift: [0.5cx, 8.95]
-        nets:
+        params:
           from: RAW
           to: BAT
-        params:
           side: B
       jstph:
-        type: jstph
-        anchor:
+        what: jstph
+        where:
           ref: matrix_four_top
           shift: [0.5cx, -1.5cy]
           rotate: 180
-        nets:
+        params:
           pos: BAT
           neg: GND
-        params:
           side: B
 `
 };

--- a/src/examples/reviung41.ts
+++ b/src/examples/reviung41.ts
@@ -3,7 +3,8 @@ import {ConfigExample} from "./index";
 const Reviung41: ConfigExample = {
     label: "Reviung41 (simplified)",
     author: "jcmkk3",
-    value: `units:
+    value: `
+units:
   # \`U\` is a predefined unit of measure that means 19.05mm, which is MX spacing
   angle: -8
 points:
@@ -20,46 +21,51 @@ points:
             column_net: P4
             mirror.column_net: P9
         pinky:
-          stagger: 0.25U
           key:
+            stagger: 0.25U
             column_net: P5
             mirror.column_net: P8
         ring:
-          stagger: 0.25U
           key:
+            stagger: 0.25U
             column_net: P6
             mirror.column_net: P7
         middle:
-          stagger: 0.25U
           key:
+            stagger: 0.25U
             column_net: P7
             mirror.column_net: P6
         index:
-          stagger: -0.25U
           key:
+            stagger: -0.25U
             column_net: P8
             mirror.column_net: P5
         inner:
-          stagger: -0.25U
           key:
+            stagger: -0.25U
             column_net: P9
             mirror.column_net: P4
       rows:
         bottom:
-          padding: U
-          row_net: P21
-          mirror.row_net: P18
+          key:
+            padding: U
+            row_net: P21
+            mirror.row_net: P18
         home:
-          padding: U
-          row_net: P20
-          mirror.row_net: P15
+          key:
+            padding: U
+            row_net: P20
+            mirror.row_net: P15
         top:
-          padding: U
-          row_net: P19
-          mirror.row_net: P14
+          key:
+            padding: U
+            row_net: P19
+            mirror.row_net: P14
     thumb_middle:
       anchor:
-        ref: [matrix_inner_bottom, mirror_matrix_inner_bottom]
+        aggregate.parts:
+          - ref: matrix_inner_bottom
+          - ref: mirror_matrix_inner_bottom
         shift: [0, -1.15U]
       key:
         name: thumb_middle
@@ -90,27 +96,33 @@ points:
         row_net: P16
         column_net: P21
         mirror.column_net: P14
-  key:
-    footprints:
-      - type: mx
-        nets:
-          from: =row_net
-          to: =column_net
-        params.keycaps: true
-      - type: diode
-        anchor:
-          shift: [0, -4.7]
-        nets:
-          from: =row_net
-          to: =colrow
 pcbs:
   simple_reviung41:
     footprints:
-      - type: promicro
-        anchor:
-          - ref: [matrix_inner_top, mirror_matrix_inner_top]
-            shift: [0, 22]
-            rotate: angle`
+      keys:
+        what: mx
+        where: true
+        params:
+          from: "{{row_net}}"
+          to: "{{column_net}}"
+          keycaps: true
+      diodes:
+        what: diode
+        where: true
+        adjust:
+          shift: [0, -4.7]
+        params:
+          from: "{{row_net}}"
+          to: "{{colrow}}"
+      mcu:
+        what: promicro
+        where:
+          aggregate.parts:
+            - ref: matrix_inner_top
+            - ref: mirror_matrix_inner_top
+          shift: [0, 22]
+          rotate: angle
+`
 };
 
 export default Reviung41;

--- a/src/examples/reviung41.ts
+++ b/src/examples/reviung41.ts
@@ -83,7 +83,7 @@ points:
         width: 1.25
         row_net: P16
         column_net: P20
-        mirror.column_net: P15 
+        mirror.column_net: P15
     thumb_tucky:
       mirror: *mirror
       anchor:

--- a/src/examples/sweeplike.ts
+++ b/src/examples/sweeplike.ts
@@ -9,10 +9,10 @@ points:
     matrix:
       columns:
         pinky:
-        ring.stagger: 0.66U
-        middle.stagger: 0.25U
-        index.stagger: -0.25U
-        inner.stagger: -0.15U
+        ring.key.stagger: 0.66U
+        middle.key.stagger: 0.25U
+        index.key.stagger: -0.25U
+        inner.key.stagger: -0.15U
       rows:
         bottom.padding: U
         home.padding: U
@@ -26,28 +26,28 @@ points:
         tucky:
           key.name: thumb_tucky
         reachy:
-          spread: U
-          rotate: -15
-          origin: [-0.5U, -0.5U]
+          key.spread: U
+          key.splay: -15
+          key.origin: [-0.5U, -0.5U]
           key.name: thumb_reachy
-  key:
-    footprints:
-      - type: mx
-        nets:
-          from: GND
-          to: =name
-        params:
-          reverse: true
-          keycaps: true
 pcbs:
   simple_split:
     footprints:
-      - type: promicro
-        anchor:
+      keys:
+        what: mx
+        where: true
+        params:
+          from: GND
+          to: =name
+          reverse: true
+          keycaps: true
+      mcu:
+        what: promicro
+        where:
           - ref: matrix_inner_home
             shift: [1U, 0.5U]
             rotate: -90
-        nets:
+        params:
           P7: matrix_pinky_top
           P18: matrix_ring_top
           P19: matrix_middle_top

--- a/src/examples/sweeplike.ts
+++ b/src/examples/sweeplike.ts
@@ -38,7 +38,7 @@ pcbs:
         where: true
         params:
           from: GND
-          to: =name
+          to: "{{name}}"
           reverse: true
           keycaps: true
       mcu:

--- a/src/examples/tiny20.ts
+++ b/src/examples/tiny20.ts
@@ -80,7 +80,7 @@ points:
         type: choc
         nets:
           from: GND
-          to: =column_net
+          to: "{{column_net}}"
         params:
           keycaps: true
           reverse: true
@@ -141,7 +141,7 @@ pcbs:
         where: true
         params:
           from: GND
-          to: =column_net
+          to: "{{column_net}}"
           keycaps: true
           reverse: true
           hotswap: false

--- a/src/examples/tiny20.ts
+++ b/src/examples/tiny20.ts
@@ -3,45 +3,50 @@ import {ConfigExample} from "./index";
 const Tiny20: ConfigExample = {
     label: "Tiny20",
     author: "enzocoralc",
-    value: `points:
+    value: `
+points:
   zones:
     matrix:
       anchor:
         rotate: 5
       columns:
         pinky:
-          spread: 18
-          rows:
-            bottom:
-              column_net: P21
-            home:
-              column_net: P20
+          key:
+            spread: 18
+            rows:
+              bottom:
+                column_net: P21
+              home:
+                column_net: P20
         ring:
-          spread: 18
-          rotate: -5
-          origin: [-12, -19]
-          stagger: 16
-          rows:
-            bottom:
-              column_net: P19
-            home:
-              column_net: P18
+          key:
+            spread: 18
+            splay: -5
+            origin: [-12, -19]
+            stagger: 16
+            rows:
+              bottom:
+                column_net: P19
+              home:
+                column_net: P18
         middle:
-          spread: 18
-          stagger: 5
-          rows:
-            bottom:
-              column_net: P15
-            home:
-              column_net: P14
+          key:
+            spread: 18
+            stagger: 5
+            rows:
+              bottom:
+                column_net: P15
+              home:
+                column_net: P14
         index:
-          spread: 18
-          stagger: -6
-          rows:
-            bottom:
-              column_net: P26
-            home:
-              column_net: P10
+          key:
+            spread: 18
+            stagger: -6
+            rows:
+              bottom:
+                column_net: P26
+              home:
+                column_net: P10
       rows:
         bottom:
           padding: 17
@@ -54,16 +59,18 @@ const Tiny20: ConfigExample = {
         rotate: 90
       columns:
         near:
-          rotate: -90
-          origin: [0,0]
+          key:
+            splay: -90
+            origin: [0,0]
           rows:
             home:
               rotate: -90
               column_net: P8
         home:
-          spread: 17
-          rotate: 90
-          origin: [0,0]
+          key:
+            spread: 17
+            rotate: 90
+            origin: [0,0]
           rows:
             home:
               column_net: P9
@@ -75,100 +82,112 @@ const Tiny20: ConfigExample = {
           from: GND
           to: =column_net
         params:
-            keycaps: true
-            reverse: true
-            hotswap: false
+          keycaps: true
+          reverse: true
+          hotswap: false
+
 outlines:
-  exports:
-    plate:
-      - type: keys
-        side: left
-        size: 18
-        corner: 3
-      - type: keys
-        side: left
-        size: 14
-        bound: false
-        operation: subtract
-    pcb_perimeter_raw:
-      - type: keys
-        side: left
-        size: 18
-        corner: 1
-    polygon:
-      - type: polygon # all borders
-        operation: stack
-        points:
-          - ref: matrix_pinky_bottom
-            shift: [-9,-9]
-          - ref: matrix_pinky_home
-            shift: [-9,1.3u]
-          - ref: matrix_middle_home
-            shift: [-9,9]
-          - ref: matrix_middle_home
-            shift: [9,9]
-          - ref: matrix_index_home
-            shift: [1.45u,9]
-          - ref: thumb_home_home
-            shift: [8,-9]
-          - ref: thumb_near_home
-            shift: [9,-9]
-    pcb_perimeter:
-      - type: outline # keys
-        name: pcb_perimeter_raw
-      - type: outline
-        name: polygon
-        operation: add
+  plate:
+    - what: rectangle
+      where: true
+      asym: source
+      size: 18
+      corner: 3
+    - what: rectangle
+      where: true
+      asym: source
+      size: 14
+      bound: false
+      operation: subtract
+  pcb_perimeter_raw:
+    - what: rectangle
+      where: true
+      asym: source
+      size: 18
+      corner: 1
+  polygon:
+    - what: polygon # all borders
+      operation: stack
+      points:
+        - ref: matrix_pinky_bottom
+          shift: [-9,-9]
+        - ref: matrix_pinky_home
+          shift: [-9,1.3u]
+        - ref: matrix_middle_home
+          shift: [-9,9]
+        - ref: matrix_middle_home
+          shift: [9,9]
+        - ref: matrix_index_home
+          shift: [1.45u,9]
+        - ref: thumb_home_home
+          shift: [8,-9]
+        - ref: thumb_near_home
+          shift: [9,-9]
+  pcb_perimeter:
+    - what: outline # keys
+      name: pcb_perimeter_raw
+    - what: outline
+      name: polygon
+      operation: add
+
 pcbs:
   tiny20:
     outlines:
       main:
         outline: pcb_perimeter
     footprints:
+      keys:
+        what: choc
+        where: true
+        params:
+          from: GND
+          to: =column_net
+          keycaps: true
+          reverse: true
+          hotswap: false
       promicro:
-        type: promicro
-        anchor:
+        what: promicro
+        where:
           ref: matrix_index_home
           shift: [0.95u, -0.5u]
           rotate: -90
         params:
           orientation: down
       trrs:
-        type: trrs
-        nets:
-          A: GND
-          B: GND
-          C: P1
-          D: VCC
-        anchor:
+        what: trrs
+        where:
           ref: matrix_pinky_home
           shift: [2, 1.1u]
           rotate: 0
         params:
+          A: GND
+          B: GND
+          C: P1
+          D: VCC
           reverse: true
           symmetric: true
       reset:
-        type: button
-        anchor:
+        what: button
+        where:
           ref:
             - matrix_ring_home
           shift: [-0.7u, 0]
           rotate: 90
-        nets:
+        params:
           from: RST
           to: GND
       resetbottom:
-        type: button
-        anchor:
+        what: button
+        where:
           ref:
             - matrix_ring_home
           shift: [-0.7u, 0]
           rotate: 90
-        nets:
+        params:
           from: RST
           to: GND
-        params:
-          side: B`
+          side: B
+`
 };
 
 export default Tiny20;

--- a/src/examples/wubbo.ts
+++ b/src/examples/wubbo.ts
@@ -66,7 +66,7 @@ points:
           keycaps: false
       choc:
         type: choc
-        anchor: 
+        anchor:
           rotate: 180
         nets:
           to: "{{key_net}}"

--- a/src/examples/wubbo.ts
+++ b/src/examples/wubbo.ts
@@ -56,7 +56,7 @@ points:
       choc_hotswap:
         type: choc
         nets:
-          to: =key_net
+          to: "{{key_net}}"
           from: GND
         params:
           reverse: false
@@ -69,7 +69,7 @@ points:
         anchor: 
           rotate: 180
         nets:
-          to: =key_net
+          to: "{{key_net}}"
           from: GND
         params:
           keycaps: true

--- a/src/examples/wubbo.ts
+++ b/src/examples/wubbo.ts
@@ -3,7 +3,8 @@ import {ConfigExample} from "./index";
 const Wubbo: ConfigExample = {
     label: "Wubbo (outlines, switchplate)",
     author: "cache.works",
-    value: `units:
+    value: `
+units:
   # Parameters
   row_spacing: 1cy
 
@@ -81,47 +82,53 @@ points:
         top.padding: row_spacing
       columns:
         pinkycluster:
-          rotate: pinky_rotation
+          key:
+            splay: pinky_rotation
           rows:
             bottom.skip: true
             home.key_net: P106
             top.skip: true
         pinky:
-          rotate: pinky_rotation - pinky_rotation
-          stagger: pinky_stagger
-          spread: pinky_spread
+          key:
+            splay: pinky_rotation - pinky_rotation
+            stagger: pinky_stagger
+            spread: pinky_spread
           rows:
             bottom.key_net: P104
             home.key_net: P102
             top.skip: true
         ring:
-          rotate: ring_rotation - pinky_rotation
-          stagger: ring_stagger
-          spread: ring_spread
+          key:
+            splay: ring_rotation - pinky_rotation
+            stagger: ring_stagger
+            spread: ring_spread
           rows:
             bottom.key_net: P101
             home.key_net: P103
             top.key_net: P100
         middle:
-          rotate: middle_rotation - ring_rotation
-          stagger: middle_stagger
-          spread: middle_spread
+          key:
+            splay: middle_rotation - ring_rotation
+            stagger: middle_stagger
+            spread: middle_spread
           rows:
             bottom.key_net: P022
             home.key_net: P029
             top.key_net: P030
         index:
-          rotate: index_rotation - middle_rotation
-          stagger: index_stagger
-          spread: index_spread
+          key:
+            splay: index_rotation - middle_rotation
+            stagger: index_stagger
+            spread: index_spread
           rows:
             bottom.key_net: P031
             home.key_net: P004
             top.key_net: P005
         inner:
-          rotate: inner_rotation - index_rotation
-          stagger: inner_stagger
-          spread: inner_spread
+          key:
+            splay: inner_rotation - index_rotation
+            stagger: inner_stagger
+            spread: inner_spread
           rows:
             bottom.key_net: P007
             home.key_net: P109
@@ -132,16 +139,17 @@ points:
         shift: [ 0.5cx, -1cy - 2]
       columns:
         near:
-          rotate: -10
-          stagger: -5
-          origin: [ 0, -0.5cy ]
-          key.key_net: P009
-        home:
-          spread: 19
-          stagger: 0.25cy # Move up by 0.25cy so a 1.5cy keycap lines up with the bottom
-          rotate: -15 # -25 degrees cumulative
-          origin: [-0.5choc_cap_y, -0.75choc_cap_x] # Pivot at the lower left corner of a 1.5u choc key
           key:
+            splay: -10
+            stagger: -5
+            origin: [ 0, -0.5cy ]
+            key_net: P009
+        home:
+          key:
+            spread: 19
+            stagger: 0.25cy # Move up by 0.25cy so a 1.5cy keycap lines up with the bottom
+            splay: -15 # -25 degrees cumulative
+            origin: [-0.5choc_cap_y, -0.75choc_cap_x] # Pivot at the lower left corner of a 1.5u choc key
             height: choc_cap_x
             width: 1.5choc_cap_y
             rotate: 90
@@ -153,60 +161,60 @@ points:
         thumb:
           padding: 0
 outlines:
-  exports:
-    _bottom_arch_circle:
-      - type: circle
-        radius: 500
-        anchor:
-          ref: alphas_middle_bottom
-          shift: [-95, -525]
-    _top_arch_circle:
-      - type: circle
-        radius: 200
-        anchor:
-          ref: alphas_middle_bottom
-          shift: [0, -155]
-    _main_body_circle:
-      - type: circle
-        radius: 70
-        anchor:
-          ref: alphas_middle_bottom
-          shift: [0, 0]
-    _usb_c_cutout:
-      - type: rectangle
-        size: [9.28, 6.67]
-        anchor: &usbanchor
-          ref: alphas_middle_top
-          shift: [ usb_cutout_x, usb_cutout_y ]
-          rotate: usb_cutout_r
-    # Make a crescent by overlapping two circles then cut the main body with a third circle
-    _main: [
-        +_top_arch_circle,
-        -_bottom_arch_circle,
-        ~_main_body_circle
-    ]
-    _fillet:
-      - type: outline
-        name: _main
-        fillet: 6
-    combined: [
-        _fillet,
-        -_usb_c_cutout
-    ]
-    _switch_cutouts:
-      - type: keys
-        side: left
-        size: 14 # Plate cutouts are 14mm * 14mm for both MX and Choc
-        bound: false
-    switch_plate:
-      [ combined, -_switch_cutouts]
+  _bottom_arch_circle:
+    - what: circle
+      radius: 500
+      where:
+        ref: alphas_middle_bottom
+        shift: [-95, -525]
+  _top_arch_circle:
+    - what: circle
+      radius: 200
+      where:
+        ref: alphas_middle_bottom
+        shift: [0, -155]
+  _main_body_circle:
+    - what: circle
+      radius: 70
+      where:
+        ref: alphas_middle_bottom
+        shift: [0, 0]
+  _usb_c_cutout:
+    - what: rectangle
+      size: [9.28, 6.67]
+      where: &usbanchor
+        ref: alphas_middle_top
+        shift: [ usb_cutout_x, usb_cutout_y ]
+        rotate: usb_cutout_r
+  # Make a crescent by overlapping two circles then cut the main body with a third circle
+  _main: [
+      +_top_arch_circle,
+      -_bottom_arch_circle,
+      ~_main_body_circle
+  ]
+  _fillet:
+    - what: outline
+      name: _main
+      fillet: 6
+  combined: [
+      _fillet,
+      -_usb_c_cutout
+  ]
+  _switch_cutouts:
+    - what: rectangle
+      where: true
+      asym: source
+      size: 14 # Plate cutouts are 14mm * 14mm for both MX and Choc
+      bound: false
+  switch_plate:
+    [ combined, -_switch_cutouts]
 cases:
   switchplate:
-    - type: outline
+    - what: outline
       name: switch_plate
       extrude: choc_plate_thickness
   bottom:
-    - type: outline
+    - what: outline
       name: combined
       extrude: choc_plate_thickness
 `


### PR DESCRIPTION
I saw on the discord that you were looking for PRs to help update the examples.

Progress so far:
- [x] ~absolem~ (already handled separately)
- [x] adux (had to tweak a `bind` value to avoid outline artifacts)
- [x] alpha (changed width of spacebar as `visual_x/y` not longer seem to work)
- [x] atreus
- [x] plank
- [x] reviung41
- [x] sweeplike
- [x] tiny20
- [x] wubbo (_no pcb output so should probably be double checked_)